### PR TITLE
Add test suite and initial support for PyPI publishing via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: python
+
+sudo: false
+
+python:
+  - "2.7"
+
+install: pip install --use-mirrors flake8
+
+before_script: flake8 .
+
+script: python setup.py test
+
+deploy:
+  provider: pypi
+  user: azavea
+  password:
+    secure: S4FQSkKrvNl+D+w/2hMBKf2DWmk0naC44/YMmDODsmJ0Te9iP7zs2pS9RQ9rWA9mcRMSEK3yTLcPvRTA0MBYIKcDmhCjKRNMSy/vEVtbP6+/WH+gFZvO/yq1wz/illmY6PQeN90enPOiJFff2Q5BDRRNk9zZ5yfML8bLvkJZn6A=
+  distributions: "sdist bdist_wheel"
+  skip_cleanup: true
+  on:
+    repo: azavea/majorkirby
+    tags: true

--- a/DESCRIPTION.rst
+++ b/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Puts CloudFormation stacks into motion.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7.9
+
+ADD . /app
+
+WORKDIR /app
+
+RUN python2 setup.py develop

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include DESCRIPTION.rst
+
+recursive-include tests *

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# majorkirby
-Puts cloudformation stacks into motion
+# majorkirby [![Build Status](https://travis-ci.org/azavea/majorkirby.svg)](https://travis-ci.org/azavea/majorkirby)
+
+Puts CloudFormation stacks into motion.
+
+## Testing
+
+There are two ways to run the built-in test suite. One is intended to be run locally, while the other is setup to run within a Docker container.
+
+### Local
+
+The local tests require a working installation of Python 2.7:
+
+```bash
+$ python setup.py test
+```
+
+### Docker
+
+The Docker setup builds an image with Python 2.7 installed, along with all of this project's dependencies. Build the image and launch the container with [`docker-compose`](https://docs.docker.com/compose/):
+
+```bash
+$ docker-compose build majorkirby
+$ docker-compose run majorkirby python setup.py test
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,2 @@
+majorkirby:
+  build: .

--- a/majorkirby/__init__.py
+++ b/majorkirby/__init__.py
@@ -1,4 +1,4 @@
-from .majorkirby import (
+from .majorkirby import (  # NOQA
     MKInputError,
     MKUnresolvableInputError,
     MKNoSuchOutputError,

--- a/majorkirby/majorkirby.py
+++ b/majorkirby/majorkirby.py
@@ -348,8 +348,7 @@ class StackNode(Template):
         """
 
         self.stack = self.boto_conn.describe_stacks(self.stack_name)[0]
-        self.logger.debug('%s %s', self.stack_name,
-                                self.stack.stack_status)
+        self.logger.debug('%s %s', self.stack_name, self.stack.stack_status)
         return self.stack.stack_status
 
     def _assign_outputs(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal=1
+
+[flake8]
+max-line-length=100

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,32 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup, find_packages
+from codecs import open
+from os import path
 
-setup(name='majorkirby',
-      version='0.0.0',
-      description='Puts cloudformation stacks into motion',
-      author='Sharp Hall',
-      author_email='shall@azavea.com',
-      packages=['majorkirby'],
-      requires=['troposphere (>=0.7.2)', 'boto (>=2.38.0)']
-      )
+# Get the long description from DESCRIPTION.rst
+with open(path.join(path.abspath(path.dirname(__file__)),
+          'DESCRIPTION.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+tests_require = ['moto >=0.4.1']
+
+setup(
+    name='majorkirby',
+    version='0.1.0.dev1',
+    description='Puts CloudFormation stacks into motion.',
+    author='Sharp Hall',
+    author_email='shall@azavea.com',
+    keywords='aws cloudformation',
+    packages=find_packages(exclude=['tests']),
+    install_requires=[
+        'troposphere >=0.7.2',
+        'boto >=2.38.0'
+    ],
+    extras_require={
+        'dev': [],
+        'test': tests_require
+    },
+    test_suite="tests",
+    tests_require=tests_require,
+)

--- a/tests/test_custom_action_node.py
+++ b/tests/test_custom_action_node.py
@@ -1,0 +1,25 @@
+import unittest
+
+from majorkirby import GlobalConfigNode, CustomActionNode
+
+
+class TitleCustomActionNode(CustomActionNode):
+    INPUTS = {'test': ['global:test']}
+
+    def action(self):
+        self.stack_outputs = {'test': self.get_input('test').title()}
+
+
+class TestCustomActionNode(unittest.TestCase):
+    def test_action(self):
+        stack_inputs = {'test': 'joker'}
+
+        custom_action = TitleCustomActionNode(
+            globalconfig=GlobalConfigNode(**stack_inputs)
+        )
+        custom_action.go()
+
+        self.assertEqual(custom_action.stack_outputs['test'], 'Joker')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_global_config_node.py
+++ b/tests/test_global_config_node.py
@@ -1,0 +1,15 @@
+import unittest
+
+from majorkirby import GlobalConfigNode
+
+
+class TestGlobalConfigNode(unittest.TestCase):
+    def test_stack_outputs(self):
+        stack_inputs = {'test': 'joker'}
+
+        global_config = GlobalConfigNode(**stack_inputs)
+        self.assertEqual(global_config.stack_outputs, stack_inputs)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_null_node.py
+++ b/tests/test_null_node.py
@@ -1,0 +1,8 @@
+import unittest
+
+
+class TestNullNode(unittest.TestCase):
+    pass
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_stack_node.py
+++ b/tests/test_stack_node.py
@@ -1,0 +1,43 @@
+import unittest
+
+from majorkirby import GlobalConfigNode, StackNode
+from troposphere import Output
+from moto import mock_cloudformation
+
+
+class FirstStackNode(StackNode):
+    INPUTS = {'test': ['global:test']}
+
+    def set_up_stack(self):
+        super(FirstStackNode, self).set_up_stack()
+
+        self.add_output(
+            Output('test', Value='First %s' % self.get_input('test'))
+        )
+
+
+class SecondStackNode(StackNode):
+    INPUTS = {'test': ['FirstStackNode:test']}
+
+    def set_up_stack(self):
+        self.add_output(
+            Output('test', Value='Second %s' % self.get_input('test'))
+        )
+
+
+class TestStackNode(unittest.TestCase):
+    @mock_cloudformation
+    def test_stack_threading(self):
+        global_config = GlobalConfigNode(**{'test': 'joker'})
+
+        first = FirstStackNode(globalconfig=global_config)
+        second = SecondStackNode(globalconfig=global_config,
+                                 FirstStackNode=first)
+
+        second.go()
+
+        self.assertEqual(first.stack_outputs['test'], 'First joker')
+        self.assertEqual(second.stack_outputs['test'], 'Second First joker')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This changeset adds a basic `unittest` suite for this project, along with instructions for executing it locally and inside of a Docker container. In addition, support for Travis CI was added to execute the test suite after linting.

PyPI deployment has not been tested, but it will only be triggered on Git tags.

Attempts to resolve #4 and #5.