### PR TITLE
Add ability to provide AWS region and profile

### DIFF
--- a/majorkirby/majorkirby.py
+++ b/majorkirby/majorkirby.py
@@ -127,6 +127,8 @@ class StackNode(Template):
         self.stack_outputs = {}
         self.extra_outputs = {}
         self.stack_name = self.get_stack_name()
+        self.aws_region = kwargs.get('aws_region', 'us-east-1')
+        self.aws_profile = kwargs.get('aws_profile', 'default')
 
     def connect_from(self, stack, name=None):
         """
@@ -324,7 +326,8 @@ class StackNode(Template):
         Sets up stack and launches it.
         """
         self.set_up_stack()
-        self.boto_conn = cloudformation.CloudFormationConnection()
+        self.boto_conn = cloudformation.connect_to_region(region_name=self.aws_region,
+                                                          profile_name=self.aws_profile)
         parameters = []
         for param, input_name in self.input_wiring.iteritems():
             try:

--- a/majorkirby/majorkirby.py
+++ b/majorkirby/majorkirby.py
@@ -128,7 +128,7 @@ class StackNode(Template):
         self.extra_outputs = {}
         self.stack_name = self.get_stack_name()
         self.aws_region = kwargs.get('aws_region', 'us-east-1')
-        self.aws_profile = kwargs.get('aws_profile', 'default')
+        self.aws_profile = kwargs.get('aws_profile', None)
 
     def connect_from(self, stack, name=None):
         """


### PR DESCRIPTION
Previously, the only way to establish a CloudFormation connection to a specific region, or with a specific AWS profile, had to be setup via environment variables. Now, if any StackNode is provided the `aws_region` or `aws_profile` keyword arguments, they'll make it through to Boto connection initialization.