### PR TITLE
Add support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
+dist: xenial
 language: python
-
-sudo: false
-
 python:
-  - "2.7"
+  - "3.7"
 
-install: pip install --use-mirrors flake8
+install: pip install --use-mirrors flake8 black
 
-before_script: flake8 .
+before_script:
+  - flake8 .
+  - black --check .
 
 script: python setup.py test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - "3.7"
 
+before_install: sudo rm /etc/boto.cfg
+
 install: pip install flake8 black
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - "3.7"
 
-install: pip install --use-mirrors flake8 black
+install: pip install flake8 black
 
 before_script:
   - flake8 .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM python:2.7.9
+FROM python:3-slim
 
-ADD . /app
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
 
-WORKDIR /app
+COPY . /usr/src/app
 
-RUN python2 setup.py develop
+RUN python setup.py develop

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2015 Azavea Inc.
+   Copyright 2019 Azavea Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ There are two ways to run the built-in test suite. One is intended to be run loc
 
 ### Local
 
-The local tests require a working installation of Python 2.7:
+The local tests require a working installation of Python 3:
 
 ```bash
-$ python setup.py test
+$ python3 setup.py test
 ```
 
 ### Docker
 
-The Docker setup builds an image with Python 2.7 installed, along with all of this project's dependencies. Build the image and launch the container with [`docker-compose`](https://docs.docker.com/compose/):
+The Docker setup builds an image with Python 3 installed, along with all of this project's dependencies. Build the image and launch the container with Docker Compose:
 
 ```bash
 $ docker-compose build majorkirby

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,2 +1,9 @@
-majorkirby:
-  build: .
+version: '3'
+services:
+  majorkirby:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes: 
+      - .:/usr/src/app
+    command: bash

--- a/majorkirby/__init__.py
+++ b/majorkirby/__init__.py
@@ -6,5 +6,5 @@ from .majorkirby import (  # NOQA
     MKNoSuchInputError,
     StackNode,
     GlobalConfigNode,
-    CustomActionNode
+    CustomActionNode,
 )

--- a/setup.py
+++ b/setup.py
@@ -5,28 +5,30 @@ from codecs import open
 from os import path
 
 # Get the long description from DESCRIPTION.rst
-with open(path.join(path.abspath(path.dirname(__file__)),
-          'DESCRIPTION.rst'), encoding='utf-8') as f:
+with open(
+    path.join(path.abspath(path.dirname(__file__)), "DESCRIPTION.rst"), encoding="utf-8"
+) as f:
     long_description = f.read()
 
-tests_require = ['moto >=0.4.1']
+tests_require = ["moto >=0.4.1"]
 
 setup(
-    name='majorkirby',
-    version='0.2.1',
-    description='Puts CloudFormation stacks into motion.',
-    author='Sharp Hall',
-    author_email='shall@azavea.com',
-    keywords='aws cloudformation',
-    packages=find_packages(exclude=['tests']),
-    install_requires=[
-        'troposphere >=0.7.2',
-        'boto >=2.38.0'
-    ],
-    extras_require={
-        'dev': [],
-        'test': tests_require
-    },
+    name="majorkirby",
+    version="0.2.1",
+    description="Puts CloudFormation stacks into motion.",
+    author="Sharp Hall",
+    author_email="shall@azavea.com",
+    keywords="aws cloudformation",
+    packages=find_packages(exclude=["tests"]),
+    install_requires=["troposphere>=0.7.2", "boto>=2.38.0"],
+    extras_require={"dev": [], "test": tests_require},
     test_suite="tests",
     tests_require=tests_require,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+    ],
 )

--- a/tests/test_custom_action_node.py
+++ b/tests/test_custom_action_node.py
@@ -4,22 +4,23 @@ from majorkirby import GlobalConfigNode, CustomActionNode
 
 
 class TitleCustomActionNode(CustomActionNode):
-    INPUTS = {'test': ['global:test']}
+    INPUTS = {"test": ["global:test"]}
 
     def action(self):
-        self.stack_outputs = {'test': self.get_input('test').title()}
+        self.stack_outputs = {"test": self.get_input("test").title()}
 
 
 class TestCustomActionNode(unittest.TestCase):
     def test_action(self):
-        stack_inputs = {'test': 'joker'}
+        stack_inputs = {"test": "joker"}
 
         custom_action = TitleCustomActionNode(
             globalconfig=GlobalConfigNode(**stack_inputs)
         )
         custom_action.go()
 
-        self.assertEqual(custom_action.stack_outputs['test'], 'Joker')
+        self.assertEqual(custom_action.stack_outputs["test"], "Joker")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_global_config_node.py
+++ b/tests/test_global_config_node.py
@@ -5,11 +5,11 @@ from majorkirby import GlobalConfigNode
 
 class TestGlobalConfigNode(unittest.TestCase):
     def test_stack_outputs(self):
-        stack_inputs = {'test': 'joker'}
+        stack_inputs = {"test": "joker"}
 
         global_config = GlobalConfigNode(**stack_inputs)
         self.assertEqual(global_config.stack_outputs, stack_inputs)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_null_node.py
+++ b/tests/test_null_node.py
@@ -4,5 +4,6 @@ import unittest
 class TestNullNode(unittest.TestCase):
     pass
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_stack_node.py
+++ b/tests/test_stack_node.py
@@ -2,42 +2,38 @@ import unittest
 
 from majorkirby import GlobalConfigNode, StackNode
 from troposphere import Output
-from moto import mock_cloudformation
+from moto import mock_cloudformation_deprecated
 
 
 class FirstStackNode(StackNode):
-    INPUTS = {'test': ['global:test']}
+    INPUTS = {"test": ["global:test"]}
 
     def set_up_stack(self):
         super(FirstStackNode, self).set_up_stack()
 
-        self.add_output(
-            Output('test', Value='First %s' % self.get_input('test'))
-        )
+        self.add_output(Output("test", Value="First %s" % self.get_input("test")))
 
 
 class SecondStackNode(StackNode):
-    INPUTS = {'test': ['FirstStackNode:test']}
+    INPUTS = {"test": ["FirstStackNode:test"]}
 
     def set_up_stack(self):
-        self.add_output(
-            Output('test', Value='Second %s' % self.get_input('test'))
-        )
+        self.add_output(Output("test", Value="Second %s" % self.get_input("test")))
 
 
 class TestStackNode(unittest.TestCase):
-    @mock_cloudformation
+    @mock_cloudformation_deprecated
     def test_stack_threading(self):
-        global_config = GlobalConfigNode(**{'test': 'joker'})
+        global_config = GlobalConfigNode(**{"test": "joker"})
 
         first = FirstStackNode(globalconfig=global_config)
-        second = SecondStackNode(globalconfig=global_config,
-                                 FirstStackNode=first)
+        second = SecondStackNode(globalconfig=global_config, FirstStackNode=first)
 
         second.go()
 
-        self.assertEqual(first.stack_outputs['test'], 'First joker')
-        self.assertEqual(second.stack_outputs['test'], 'Second First joker')
+        self.assertEqual(first.stack_outputs["test"], "First joker")
+        self.assertEqual(second.stack_outputs["test"], "Second First joker")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Updated the module to support Python 3:

- Used `future` to convert Python 2 specific code to Python 3
- Used `black` to format source code now that it is Python 3 compatible

In addition:

- Got test suite working again by using `_deprecated` methods from Moto
- Updated Travis CI configuration to target Python 3.7

---

**Testing**

Test this PR via https://github.com/azavea/cicero/pull/1813.